### PR TITLE
Removes maliput_drake from CI.

### DIFF
--- a/.github/dependencies.repos
+++ b/.github/dependencies.repos
@@ -7,10 +7,6 @@ repositories:
     type: git
     url: https://github.com/maliput/maliput_py
     version: main
-  maliput_drake:
-    type: git
-    url: https://github.com/maliput/maliput_drake
-    version: main
   maliput_malidrive:
     type: git
     url: https://github.com/maliput/maliput_malidrive


### PR DESCRIPTION
# 🎉 New feature

Related to https://github.com/maliput/maliput_infrastructure/issues/309

:exclamation: :star2:  This PR needs to be merged in sync with others!

## Checklist
- [x] Signed all commits for DCO
- [ ] Added tests
- [ ] Added example and/or tutorial
- [ ] Updated documentation (as needed)
- [ ] Updated migration guide (as needed)
- [ ] Consider updating Python bindings (if it affects the public API)

action-ros-ci-repos-override: https://gist.githubusercontent.com/francocipollone/296d5eaf16a2af8f52a23193b8ef9489/raw/b525dc6267e61ad6edc6d655f122392fdaf4a15b/maliput_sim.repos

